### PR TITLE
Fix a load of things

### DIFF
--- a/LoaderHandler.js
+++ b/LoaderHandler.js
@@ -4,7 +4,7 @@
 
 import { DeviceEventEmitter } from 'react-native';
 
-let loaderHandler = {
+const loaderHandler = {
   hideLoader () {
     DeviceEventEmitter.emit('changeLoadingEffect', {isVisible: false});
   },

--- a/LoaderHandler.js
+++ b/LoaderHandler.js
@@ -2,18 +2,14 @@
  * Created by Durgaprasad Budhwani on 1/2/2016.
  */
 
-import EventEmitter from 'EventEmitter';
-let eventEmitter = new EventEmitter();
+import { DeviceEventEmitter } from 'react-native';
 
 let loaderHandler = {
-  getEventEmitter () {
-    return eventEmitter;
-  },
   hideLoader () {
-    eventEmitter.emit('changeLoadingEffect', {isVisible: false});
+    DeviceEventEmitter.emit('changeLoadingEffect', {isVisible: false});
   },
   showLoader (title) {
-    eventEmitter.emit('changeLoadingEffect', {title, isVisible: true});
+    DeviceEventEmitter.emit('changeLoadingEffect', {title, isVisible: true});
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
  */
 
 import React from 'react-native';
-import Subscribable from 'Subscribable';
+import { DeviceEventEmitter } from 'react-native';
 import loaderHandler  from './LoaderHandler';
 import Loading  from './loading';
 
@@ -11,7 +11,7 @@ let {
   StyleSheet,
   View,
   Text
-  } = React;
+} = React;
 
 let styles = StyleSheet.create({
   container: {
@@ -43,7 +43,6 @@ let BusyIndicator = React.createClass({
     textColor: React.PropTypes.string,
     textFontSize: React.PropTypes.number
   },
-  mixins: [Subscribable.Mixin],
 
   getDefaultProps() {
     return {
@@ -64,11 +63,14 @@ let BusyIndicator = React.createClass({
     };
   },
   componentDidMount () {
-    this.addListenerOn(loaderHandler.getEventEmitter(), 'changeLoadingEffect', this.changeLoadingEffect, null);
+    this.emitter = DeviceEventEmitter.addListener('changeLoadingEffect', this.changeLoadingEffect, null);
   },
 
+  componentDidUnmount() {
+    this.emitter.remove();
+  }
+
   changeLoadingEffect(state) {
-    //noinspection JSUnresolvedFunction
     this.setState({
       isVisible: state.isVisible,
       text: state.title != null ? state.title : 'Please wait...'
@@ -113,5 +115,3 @@ let BusyIndicator = React.createClass({
 });
 
 module.exports = BusyIndicator;
-
-

--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@
  * Created by Durgaprasad Budhwani on 1/2/2016.
  */
 
-import React, { DeviceEventEmitter } from 'react-native';
+import React from 'react';
+import { DeviceEventEmitter } from 'react-native';
 import Loading  from './loading';
 
 const {

--- a/index.js
+++ b/index.js
@@ -2,18 +2,16 @@
  * Created by Durgaprasad Budhwani on 1/2/2016.
  */
 
-import React from 'react-native';
-import { DeviceEventEmitter } from 'react-native';
-import loaderHandler  from './LoaderHandler';
+import React, { DeviceEventEmitter } from 'react-native';
 import Loading  from './loading';
 
-let {
+const {
   StyleSheet,
   View,
   Text
 } = React;
 
-let styles = StyleSheet.create({
+const styles = StyleSheet.create({
   container: {
     position: 'absolute',
     backgroundColor: 'rgba(0,0,0,0.3)',
@@ -33,7 +31,7 @@ let styles = StyleSheet.create({
   }
 });
 
-let BusyIndicator = React.createClass({
+const BusyIndicator = React.createClass({
   propTypes: {
     color: React.PropTypes.string,
     overlayColor: React.PropTypes.string,
@@ -68,7 +66,7 @@ let BusyIndicator = React.createClass({
 
   componentDidUnmount() {
     this.emitter.remove();
-  }
+  },
 
   changeLoadingEffect(state) {
     this.setState({
@@ -79,7 +77,7 @@ let BusyIndicator = React.createClass({
 
 
   render() {
-    let customStyles = StyleSheet.create({
+    const customStyles = StyleSheet.create({
       overlay: {
         alignItems: 'center',
         justifyContent: 'center',

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ const BusyIndicator = React.createClass({
     this.emitter = DeviceEventEmitter.addListener('changeLoadingEffect', this.changeLoadingEffect, null);
   },
 
-  componentDidUnmount() {
+  componentWillUnmount() {
     this.emitter.remove();
   },
 

--- a/index.js
+++ b/index.js
@@ -3,14 +3,14 @@
  */
 
 import React from 'react';
-import { DeviceEventEmitter } from 'react-native';
 import Loading  from './loading';
 
-const {
+import {
   StyleSheet,
   View,
-  Text
-} = React;
+  Text,
+  DeviceEventEmitter
+} from 'react-native';
 
 const styles = StyleSheet.create({
   container: {

--- a/loading.android.js
+++ b/loading.android.js
@@ -2,7 +2,8 @@
  * Created by Durgaprasad Budhwani on 1/5/2016.
  */
 
-import React, {ProgressBarAndroid} from 'react-native';
+import React from 'react';
+import { ProgressBarAndroid } from 'react-native';
 
 export default class Loading extends React.Component {
   static propTypes = {

--- a/loading.ios.js
+++ b/loading.ios.js
@@ -2,7 +2,8 @@
  * Created by Durgaprasad Budhwani on 1/5/2016.
  */
 
-import React, {ActivityIndicatorIOS} from 'react-native';
+import React from 'react';
+import { ActivityIndicatorIOS } from 'react-native';
 
 export default class Loading extends React.Component {
   static propTypes = {


### PR DESCRIPTION
There are a load of problems using this module in the more recent versions of `react-native`. This PR should fix them for versions `< 0.25`.
Fixes: 
- No `EventEmitter` module
- No `Subscribable` module ( see #1 )
- Use `const` wherever possible
- Minor code cleanup
- Get `React.createElement` etc from `react` not `react-native`
