### PR TITLE
Set busy indicator bottom height based on keyboard height

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,16 +58,19 @@ class BusyIndicator extends React.Component {
     };
   }
 
+  componentWillMount () {
+    this.keyboardDidShowListener = Keyboard.addListener('keyboardDidShow', this.changeKeyboardSpace.bind(this));
+    this.keyboardDidHideListener = Keyboard.addListener('keyboardDidHide', this.removeKeyboardSpace.bind(this));
+  }
+
   componentDidMount () {
-    this.emitter = DeviceEventEmitter.addListener('changeLoadingEffect', this.changeLoadingEffect.bind(this));
-    this.keyboardShowEvent = Keyboard.addListener('keyboardDidShow', this.changeKeyboardSpace.bind(this));
-    this.keyboardHideEvent = Keyboard.addListener('keyboardDidHide', this.removeKeyboardSpace.bind(this));        
+    this.emitter = DeviceEventEmitter.addListener('changeLoadingEffect', this.changeLoadingEffect.bind(this));         
   }
 
   componentWillUnmount() {
     this.emitter.remove();
-    this.keyboardShowEvent.remove();
-    this.keyboardHideEvent.remove();
+    this.keyboardDidShowListener.remove();
+    this.keyboardDidHideListener.remove();
   }
 
   changeKeyboardSpace(frames){

--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ import {
   View,
   Text,
   DeviceEventEmitter,
-  ActivityIndicator
+  ActivityIndicator,
+  Keyboard
 } from 'react-native';
 
 const styles = StyleSheet.create({
@@ -52,16 +53,30 @@ class BusyIndicator extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      isVisible: props.startVisible
+      isVisible: props.startVisible,
+      keyboardSpace: 0,
     };
   }
 
   componentDidMount () {
     this.emitter = DeviceEventEmitter.addListener('changeLoadingEffect', this.changeLoadingEffect.bind(this));
+    this.keyboardShowEvent = Keyboard.addListener('keyboardDidShow', (frames) => {
+      if (!frames.endCoordinates) return;
+      this.setState({
+        keyboardSpace: frames.endCoordinates.height
+      });
+    });
+    this.keyboardHideEvent = Keyboard.addListener('keyboardDidHide', (frames) => {
+      this.setState({
+        keyboardSpace: 0
+      });
+    });        
   }
 
   componentWillUnmount() {
     this.emitter.remove();
+    this.keyboardShowEvent.remove();
+    this.keyboardHideEvent.remove();
   }
 
   changeLoadingEffect(state) {
@@ -90,7 +105,7 @@ class BusyIndicator extends React.Component {
     });
 
     return (
-      <View style={styles.container}>
+      <View style={[styles.container, { bottom: this.state.keyboardSpace }]}>
         <View style={[styles.overlay, customStyles.overlay]}>
           <ActivityIndicator
             color={this.props.color}

--- a/index.js
+++ b/index.js
@@ -54,29 +54,33 @@ class BusyIndicator extends React.Component {
     super(props);
     this.state = {
       isVisible: props.startVisible,
-      keyboardSpace: 0,
+      keyboardSpace: 0
     };
   }
 
   componentDidMount () {
     this.emitter = DeviceEventEmitter.addListener('changeLoadingEffect', this.changeLoadingEffect.bind(this));
-    this.keyboardShowEvent = Keyboard.addListener('keyboardDidShow', (frames) => {
-      if (!frames.endCoordinates) return;
-      this.setState({
-        keyboardSpace: frames.endCoordinates.height
-      });
-    });
-    this.keyboardHideEvent = Keyboard.addListener('keyboardDidHide', (frames) => {
-      this.setState({
-        keyboardSpace: 0
-      });
-    });        
+    this.keyboardShowEvent = Keyboard.addListener('keyboardDidShow', this.changeKeyboardSpace.bind(this));
+    this.keyboardHideEvent = Keyboard.addListener('keyboardDidHide', this.removeKeyboardSpace.bind(this));        
   }
 
   componentWillUnmount() {
     this.emitter.remove();
     this.keyboardShowEvent.remove();
     this.keyboardHideEvent.remove();
+  }
+
+  changeKeyboardSpace(frames){
+    if (!frames.endCoordinates) return;
+    this.setState({
+      keyboardSpace: frames.endCoordinates.height
+    });
+  }
+
+  removeKeyboardSpace(frames){
+    this.setState({
+      keyboardSpace: 0
+    });
   }
 
   changeLoadingEffect(state) {

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ class BusyIndicator extends React.Component {
   }
 
   componentDidMount () {
-    this.emitter = DeviceEventEmitter.addListener('changeLoadingEffect', this.changeLoadingEffect.bind(this));         
+    this.emitter = DeviceEventEmitter.addListener('changeLoadingEffect', this.changeLoadingEffect.bind(this));
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
This busy indicator is covered up by soft keyboard. I add some code to prevent this happen. Thanks.

Before:
![simulator screen shot 15 aug 2017 2 31 21 pm](https://user-images.githubusercontent.com/12872679/29304839-dadd1ea6-81c7-11e7-8e49-96fa0103ca03.png)

After:
![simulator screen shot 15 aug 2017 2 28 43 pm](https://user-images.githubusercontent.com/12872679/29304845-eb2ef356-81c7-11e7-964c-6ee995cdc64e.png)
