### PR TITLE
Use prop-types package to define properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ import {
   DeviceEventEmitter,
   ActivityIndicator
 } from 'react-native';
+import PropTypes from 'prop-types';
 
 const styles = StyleSheet.create({
   container: {
@@ -109,16 +110,16 @@ class BusyIndicator extends React.Component {
 }
 
 BusyIndicator.propTypes = {
-  color: React.PropTypes.string,
-  overlayColor: React.PropTypes.string,
-  overlayHeight: React.PropTypes.number,
-  overlayWidth: React.PropTypes.number,
-  size: React.PropTypes.oneOf(['small', 'large']),
-  startVisible: React.PropTypes.bool,
-  text: React.PropTypes.string,
-  textColor: React.PropTypes.string,
-  textFontSize: React.PropTypes.number,
-  textNumberOfLines: React.PropTypes.number
+  color: PropTypes.string,
+  overlayColor: PropTypes.string,
+  overlayHeight: PropTypes.number,
+  overlayWidth: PropTypes.number,
+  size: PropTypes.oneOf(['small', 'large']),
+  startVisible: PropTypes.bool,
+  text: PropTypes.string,
+  textColor: PropTypes.string,
+  textFontSize: PropTypes.number,
+  textNumberOfLines: PropTypes.number
 };
 
 BusyIndicator.defaultProps = {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "author": "Durgaprasad Budhwani",
   "license": "MIT",
   "peerDependencies": {
-    "react-native": ">=0.25.0"
+    "react-native": ">=0.25.0",
+    "prop-types": ">=15.6.0"
   }
 }


### PR DESCRIPTION
Duplicate of https://github.com/RealOrangeOne/react-native-busy-indicator/pull/21 but with @RealOrangeOne requested changes.